### PR TITLE
Improve <input type=date>

### DIFF
--- a/src/features/CustomRange.js
+++ b/src/features/CustomRange.js
@@ -33,19 +33,25 @@ const CustomRange = () => {
       )}
       data-testid="CustomRange"
     >
-      <span className={bootstrap['input-group-text']}>Start:</span>
+      <label htmlFor="dateStart" className={bootstrap['input-group-text']}>
+        Start:
+      </label>
       <input
-        className={bootstrap['form-control']}
+        className={cx(bootstrap['form-control'], styles.inputDate)}
         type="date"
+        id="dateStart"
         value={dayjs(start).format('YYYY-MM-DD')}
         onChange={({ target }) =>
           dispatch(changeStart(new Date(target.value).toJSON()))
         }
       />
-      <span className={bootstrap['input-group-text']}>End:</span>
+      <label htmlFor="dateEnd" className={bootstrap['input-group-text']}>
+        End:
+      </label>
       <input
-        className={bootstrap['form-control']}
+        className={cx(bootstrap['form-control'], styles.inputDate)}
         type="date"
+        id="dateEnd"
         value={dayjs(end).format('YYYY-MM-DD')}
         onChange={({ target }) =>
           dispatch(changeEnd(new Date(target.value).toJSON()))

--- a/src/features/CustomRange.module.css
+++ b/src/features/CustomRange.module.css
@@ -1,3 +1,16 @@
 .component {
   text-align: left;
 }
+
+.inputDate::-webkit-calendar-picker-indicator {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  width: auto;
+  height: auto;
+  background: transparent;
+  color: transparent;
+  cursor: pointer;
+}


### PR DESCRIPTION
- use `<label>` instead of `<span>`
- open calendar interface on input click (in desktop chrome)