### PR TITLE
Add "All calendars" option

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "scripts": {
     "start": "node scripts/start.js",
     "build": "node scripts/build.js",
-    "test": "node scripts/test.js",
+    "test": "TZ=Europe/Berlin node scripts/test.js",
     "lint": "eslint --ext js src",
     "lint:css": "stylelint 'src/**/*.css'",
     "prettier": "prettier-eslint --write $PWD'/src/**/*.{js,md}'"

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -274,6 +274,39 @@ it('renders correctly after user changes calendar', async () => {
   expect(await screen.findByText('1h')).toBeInTheDocument();
 });
 
+it('renders correctly when selecting two calendars', async () => {
+  mockCalendarResponse.mockReturnValue([
+    { id: 'test-id', label: 'test-name' },
+    { id: 'test-id-2', label: 'test-name-2' },
+  ]);
+  mockEventsResponse.mockReturnValue(testEvents);
+
+  renderApp();
+
+  fireEvent.change(await screen.findByTestId('CalendarsList'), {
+    target: { value: 'test-id,test-id-2' },
+  });
+
+  expect(await screen.findByText('2h')).toBeInTheDocument();
+});
+
+it('renders correctly when selecting all calendars', async () => {
+  mockCalendarResponse.mockReturnValue([
+    { id: 'test-id', label: 'test-name' },
+    { id: 'test-id-2', label: 'test-name-2' },
+    { id: 'test-id-3', label: 'test-name-3' },
+  ]);
+  mockEventsResponse.mockReturnValue(testEvents);
+
+  renderApp();
+
+  fireEvent.change(await screen.findByTestId('CalendarsList'), {
+    target: { value: 'test-id,test-id-2,test-id-3' },
+  });
+
+  expect(await screen.findByText('3h')).toBeInTheDocument();
+});
+
 it('requests events, display hours and sets localStorage when loaded', async () => {
   renderApp();
 

--- a/src/features/CalendarsList.js
+++ b/src/features/CalendarsList.js
@@ -31,6 +31,9 @@ const CalendarsList = () => {
           {label}
         </option>
       ))}
+      <option key="all-calendars" value={calendars.map(({ id }) => (id))}>
+        All calendars
+      </option>
     </select>
   );
 };

--- a/src/stores/viewState.js
+++ b/src/stores/viewState.js
@@ -2,7 +2,7 @@ import { createSlice } from '@reduxjs/toolkit';
 import dayjs from 'dayjs';
 import 'dayjs/locale/de';
 
-import { loadCalendarEvents, selectCalendarEvents } from './calendarEvents';
+import { loadCalendarsEvents, selectCalendarEvents } from './calendarEvents';
 import { updateConfig } from './storage';
 import { RANGE_TYPE, WEEK_START } from '../constants';
 import roundHours from '../utils/roundHours';
@@ -147,13 +147,10 @@ export const selectHours = (state) => {
   return roundHours(hours);
 };
 
-export const setSelectedCalendar = ({ calendarId }) => (dispatch, getState) => {
+export const setSelectedCalendar = ({ calendarId }) => (dispatch) => {
   dispatch(setSelectedCalendarId(calendarId));
   updateConfig({ selectedCalendarId: calendarId });
-  const calendarEvents = selectCalendarEvents(getState(), calendarId);
-  if (!calendarEvents) {
-    dispatch(loadCalendarEvents({ calendarId }));
-  }
+  dispatch(loadCalendarsEvents({ calendarIdsString: calendarId }));
 };
 
 export const changeRangeType = ({ range }) => (dispatch, getState) => {


### PR DESCRIPTION
Added an "All calendars" option to load and merge events from all accessible calendars

- Add an "All calendars" option to the CalendarsList
- Refactor LoadCalendarEvents to load only unfetched calendars
- Replace LoadCalendarEvents with LoadCalendarsEvents to accept lists
- Store Calendar loading state separately to support parallel fetching
- Add tests for multiple calendars selection
- Set "npm test" command to match the TZ used to generate string snapshots in tests